### PR TITLE
fix(env.yaml, readme): add missing space and use matching env name 'm3mad'

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ We recommend Conda (or Mamba) for dependency management:
 
 ```bash
 conda env create -f env.yaml
-conda activate mad
+conda activate m3mad
 ```
 
 The environment includes OpenAI-compatible clients, vision-language dependencies, and experiment tooling. You may safely remove the `prefix` field from `env.yaml` if it points to a user-specific path.

--- a/env.yaml
+++ b/env.yaml
@@ -1,4 +1,4 @@
-name:m3mad
+name: m3mad
 channels:
   - defaults
   - https://repo.anaconda.com/pkgs/main


### PR DESCRIPTION
## Summary

Per #2, two related fixes:

- \`env.yaml:1\`: \`name:m3mad\` -> \`name: m3mad\`. YAML requires a space after the key; without it, \`conda env create -f env.yaml\` fails to parse the name.
- \`README.md\` Environment Setup block: \`conda activate mad\` -> \`conda activate m3mad\`, matching the env name produced by \`env.yaml\`.

Closes #2

## Testing

Copy-paste the fixed Environment Setup block now cleanly creates and activates the \`m3mad\` env.